### PR TITLE
fix default to 15 minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # duckdns
-Instead of using cronjobs and/or any other loop script, let us use Systemd timers to update our domains at DuckDNS. The default Systemd timers are set on every 5 minutes, you can change this yourself
+
+Instead of using cronjobs and/or any other loop script, let us use Systemd timers to update our domains at DuckDNS. The default Systemd timers are set on every 15 minutes, you can change this yourself
 
 ## Installation
 
 ### Arch/AUR
+
 info coming soon, probably will be packaged under the name [duckdns](https://aur.archlinux.org/packages/?O=0&K=duckdns)
 
 ### Other Linux distro's
@@ -12,26 +14,24 @@ Execute these comments
 
 Clone/download this repo on your computer
 
-	mv duckdns.sh /usr/bin/duckdns
-	chmod +x /usr/bin/duckdns
-	mv duckdns.service /usr/lib/systemd/system/
-	mv duckdns.timer /usr/lib/systemd/system/
-	
-	mkdir -p /etc/duckdns.d
-	mv default.cfg /etc/duckdns.d/
-	
-	systemctl enable duckdns.timer
-	systemctl start duckdns.timer
+    mv duckdns.sh /usr/bin/duckdns
+    chmod +x /usr/bin/duckdns
+    mv duckdns.service /usr/lib/systemd/system/
+    mv duckdns.timer /usr/lib/systemd/system/
 
+    mkdir -p /etc/duckdns.d
+    mv default.cfg /etc/duckdns.d/
+
+    systemctl enable duckdns.timer
+    systemctl start duckdns.timer
 
 ### Configuration
 
 the **default.cfg** file shows perfectly what options you must enter, you can create new files if you have multiple domains with the same setup.
 
-	duckdns_hostname=
-	duckdns_token=
+    duckdns_hostname=
+    duckdns_token=
 
 Nothing more is needed.
 
-Config files must be placed inside the `/etc/duckdns.d`  folder
-
+Config files must be placed inside the `/etc/duckdns.d` folder

--- a/duckdns.timer
+++ b/duckdns.timer
@@ -1,5 +1,5 @@
 [Unit]
-Description=Run DuckDNS every 5 minutes
+Description=Run DuckDNS every 15 minutes
 
 [Timer]
 OnCalendar=*:0/15


### PR DESCRIPTION
The default timer value is already fixed in 15 minutes. I only propose two silly changes in the descriptor text to match reality.